### PR TITLE
Improve sample commit title for short format

### DIFF
--- a/git.md
+++ b/git.md
@@ -177,7 +177,7 @@ where `<command>` is a smart commit command (see 3. in supplementary reading
 above). For example:
 
 ```git
-Some commit title ISSUE-51 #resolve #time 2h30m
+Fix nasty little bug ISSUE-51 #resolve #time 2h30m
 ```
 
 ### 3. Merging


### PR DESCRIPTION
The provided short format was incorporating a title that might be
somewhat confusing for the reader as it was not complying to the
`<title>` requirements stated above. I've changed it to match the
guidelines.