### PR TITLE
Create first draft of Wiki checklist

### DIFF
--- a/async_remote.md
+++ b/async_remote.md
@@ -1,0 +1,27 @@
+[other sections soon to follow]
+
+# Knowledge transfer
+
+## Wiki checklist
+
+### Index
+  List and describe all the tools, services and things used in the project.
+  
+### Glossary
+  List and describe most important and required-to-know concepts and terminology used in the project.
+  This section should usually provide newly onboarded team members with important know-how on what means what in the project.
+  Weird acronyms? Overloaded terms which mean different things in normal life? Proper names (_pl. nazwy wlasne_)? They all should be here.
+  
+### Description/guide for specific tools
+  List and describe all developer, design or management tools used in the project.
+  For example, if you're using Zeplin for UI design list it hear and mention what it's for (since not everyone will be familar at first).
+  Are you using CodeClimate for static analysis? List it here. And so on.
+  
+  Also, if the tool requires some kind of usage protocol, or it's not obvious how it's used (e.g. Firebase/Sentry), it all should be described here.
+  
+### Who is who? Who is responsible for what? Where to go for know-how?
+  List and describe team roles (both of our team and client's). Additionally, if in your team team-members are responsible for application/system/code components,
+  it's a good place to list it here too.
+  
+### Project's gotchas and must-have know-how
+  List and describe any project-specific knowledge that is required but doesn't fit other sections.


### PR DESCRIPTION
I'm adding a first draft of the generic project Wiki checklist.

Wikis should be used for better knowledge transfer in async-remote projects, or projects which are simply to big to be contained in a single mind.

Going forward, I think, Wikis should be a common place in most projects.